### PR TITLE
bump minSdk to version 29

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.zephr.sampleclient"
-        minSdk = 31
+        minSdk = 29
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
zephr sdk is not compiled with minSdk 29 instead of 31