### PR TITLE
use new zephrLib maven group id naming convention (which supports per…

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ maven {
 Then, add the SDK to your `dependencies` block:
 
 ```kotlin
-implementation("com.zephr.library:zephrLib:0.0.1-SNAPSHOT") {
+implementation("com.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
     isChanging = true // SDK updates frequently; always fetch latest during preview.
 }
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.zephr.library:zephrLib:0.0.1-SNAPSHOT") {
+    implementation("com.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
         isChanging = true // <== zephr sdk snapshot is updated multiple times per day during preview period for bug fixes and improvements -- but note that the app api should be relatively stable
     }
 


### PR DESCRIPTION
The maven artifact groupId is now unique per pr to simplify e2e artifact testing