### PR TITLE
maven library and package renamed to `xyz.zephr.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ maven {
 Then, add the SDK to your `dependencies` block:
 
 ```kotlin
-implementation("com.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
+implementation("xyz.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
     isChanging = true // SDK updates frequently; always fetch latest during preview.
 }
 ```
@@ -160,7 +160,7 @@ You can initialize the SDK and attach handlers for the sdk output using the buil
   val zephrRealtimeSDK = ZephrRealtimeSDK.Builder(this.baseContext).build()
 
   zephrRealtimeSDK.requestLocationUpdates(object : ZephrEventListener {
-      override fun onZephrGnssReceived(zephrGnssEvent: com.zephr.sdk.v2.model.ZephrGnssEvent) {
+      override fun onZephrGnssReceived(zephrGnssEvent: xyz.zephr.sdk.v2.model.ZephrGnssEvent) {
           val status = zephrGnssEvent.status
           val location = zephrGnssEvent.location
           if (location != null) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
+    implementation("xyz.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
         isChanging = true // <== zephr sdk snapshot is updated multiple times per day during preview period for bug fixes and improvements -- but note that the app api should be relatively stable
     }
 

--- a/app/src/main/java/xyz/zephr/sampleclient/MainActivity.kt
+++ b/app/src/main/java/xyz/zephr/sampleclient/MainActivity.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContextCompat
 import xyz.zephr.sampleclient.ui.theme.ZephrSampleClientAppTheme
-import com.zephr.sdk.v2.ZephrEventListener
-import com.zephr.sdk.v2.ZephrRealtimeSDK
-import com.zephr.sdk.v2.model.ZephrPoseEvent
+import xyz.zephr.sdk.v2.ZephrEventListener
+import xyz.zephr.sdk.v2.ZephrRealtimeSDK
+import xyz.zephr.sdk.v2.model.ZephrPoseEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -72,7 +72,7 @@ class MainActivity : ComponentActivity() {
         val zephrRealtimeSDK = ZephrRealtimeSDK.Builder(this.baseContext).build()
 
         zephrRealtimeSDK.requestLocationUpdates(object : ZephrEventListener {
-            override fun onZephrGnssReceived(zephrGnssEvent: com.zephr.sdk.v2.model.ZephrGnssEvent) {
+            override fun onZephrGnssReceived(zephrGnssEvent: xyz.zephr.sdk.v2.model.ZephrGnssEvent) {
                 val status = zephrGnssEvent.status
                 val location = zephrGnssEvent.location
                 if (location != null) {


### PR DESCRIPTION
App update steps:

- change reference to package in gradle to look like this

```
    implementation("xyz.zephr.library.pr-0:zephrLib:0.0.1-SNAPSHOT") {
        isChanging = true // <== zephr sdk snapshot is updated multiple times per day during preview period for bug fixes and improvements -- but note that the app api should be relatively stable
    }
```

- search and replace `com.zephr.` with `xyz.zephr.`
